### PR TITLE
remove install enterprise cli step

### DIFF
--- a/labs/linux-macOS/lab0_prerequisites.md
+++ b/labs/linux-macOS/lab0_prerequisites.md
@@ -65,13 +65,6 @@ Additionally, if the TLS certificate used by DC/OS is not trusted, you can run t
 dcos config set core.ssl_verify false
 ```
 
-## Install the DC/OS Enterprise CLI
-Run the following command to add the DC/OS Enterprise extensions to the DC/OS CLI:
-
-```
-dcos package install --yes --cli dcos-enterprise-cli
-```
-
 ## Lab Variables
 Run the following command to export the environment variables needed during the labs:
 


### PR DESCRIPTION
Installing the DC/OS Enterprise CLI is done automatically with CLI setup in 1.13. Step no longer needed.